### PR TITLE
Add Buffer to valid props of Image component

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -83,8 +83,8 @@ Defines the source of an image. Can be in any of these four valid forms:
 | String      |                                           Valid image URL or filesystem path (Node only)                                            | `www.react-pdf.org/test.jpg`                               |
 | URL object  |                                       Enables to pass extra parameters on how to fetch images                                       | `{ uri: valid-url, method: 'GET', headers: {}, body: '' }` |
 | Buffer      | Renders image directly from Buffer. Image format (png or jpg) will be guessed based on Buffer.                                      | `Buffer`                                                   |
-| Data buffer | Renders buffer image via the _data_ key. It's also recommended to provide the image _format_ so the engine knows how to proccess it | `{ data: Buffer, format: 'png' | 'jpg' }`                  |
-| Function    |                    A function that returns (can also return a promise that resolves to) any of the above formats                    | `() => String | Promise<String>`                           |
+| Data buffer | Renders buffer image via the _data_ key. It's also recommended to provide the image _format_ so the engine knows how to proccess it | `{ data: Buffer, format: 'png' \| 'jpg' }`                  |
+| Function    |                    A function that returns (can also return a promise that resolves to) any of the above formats                    | `() => String \| Promise<String>`                           |
 
 ---
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -82,8 +82,9 @@ Defines the source of an image. Can be in any of these four valid forms:
 | ----------- | :---------------------------------------------------------------------------------------------------------------------------------: | ---------------------------------------------------------- |
 | String      |                                           Valid image URL or filesystem path (Node only)                                            | `www.react-pdf.org/test.jpg`                               |
 | URL object  |                                       Enables to pass extra parameters on how to fetch images                                       | `{ uri: valid-url, method: 'GET', headers: {}, body: '' }` |
-| Data buffer | Renders buffer image via the _data_ key. It's also recommended to provide the image _format_ so the engine knows how to proccess it | `{ data: Buffer, format: 'png' \| 'jpg' }`                 |
-| Function    |                    A function that returns (can also return a promise that resolves to) any of the above formats                    | `() => String \| Promise<String>`                          |
+| Buffer      | Renders image directly from Buffer. Image format (png or jpg) will be guessed based on Buffer.                                      | `Buffer`                                                   |
+| Data buffer | Renders buffer image via the _data_ key. It's also recommended to provide the image _format_ so the engine knows how to proccess it | `{ data: Buffer, format: 'png' | 'jpg' }`                  |
+| Function    |                    A function that returns (can also return a promise that resolves to) any of the above formats                    | `() => String | Promise<String>`                           |
 
 ---
 


### PR DESCRIPTION
1. Add `Buffer` to valid props of Image, which is in fact [valid](https://github.com/diegomura/react-pdf/blob/66d6259971e99846602d69de85fcbba98825d608/packages/types/image.d.ts#L11-L15).
2. Remove char `\` from example column.