### PR TITLE
feat: proper documentation of Named Destinations

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,9 +1,9 @@
 import EditButton from '../src/components/Docs/EditButton'
 import NavigationButtons from '../src/components/Docs/NavigationButtons'
 
-import OnTheFly from './on-the-fly.md'
 import PageWrapping from './page-wrapping.md'
-import Bookmarks from './bookmarks.md'
+import DocumentNavigation from './document-navigation.md'
+import OnTheFly from './on-the-fly.md'
 import OrphanWidowProtection from './orphan-widow-protection.md'
 import DynamicContent from './dynamic-content.md'
 import Hyphenation from './hyphenation.md'
@@ -15,7 +15,7 @@ import Express from './express.md'
 ## Advanced
 
 <PageWrapping components={components} />
-<Bookmarks components={components} />
+<DocumentNavigation components={components} />
 <OnTheFly components={components} />
 <OrphanWidowProtection components={components} />
 <DynamicContent components={components} />

--- a/docs/components.md
+++ b/docs/components.md
@@ -62,13 +62,14 @@ Represents single page inside the PDF documents, or a subset of them if using th
 #### Valid props
 
 | Prop name   |                                                                                                         Description                                                                                                         |                                            Type |      Default |
-| ----------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | ----------------------------------------------: | -----------: |
+|-------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|------------------------------------------------:|-------------:|
 | size        | Defines page size. If _String_, must be one of the [available page sizes](https://github.com/diegomura/react-pdf/blob/master/packages/layout/src/page/getSize.js). Height is optional, if ommited it will behave as "auto". |           _String_, _Array_, _Number_, _Object_ |       _"A4"_ |
 | orientation |                                                                             Defines page orientation. _Valid values: "portrait" or "landscape"_                                                                             |                                        _String_ | _"portrait"_ |
 | wrap        |                                                                          Enables page wrapping for this page. [See more](/advanced#page-wrapping)                                                                           |                                       _Boolean_ |       _true_ |
 | style       |                                                                                          Defines page styles. [See more](/styling)                                                                                          |                               _Object_, _Array_ |  _undefined_ |
 | debug       |                                                                          Enables debug mode on page bounding box. [See more](/advanced#debugging)                                                                           |                                       _Boolean_ |      _false_ |
 | dpi         |                                                                                       Enables setting a custom DPI for page contents.                                                                                       |                                        _Number_ |         _72_ |
+| id          |                                                                       Destination to link to. Must begin with `#`. [See more](/advanced#destinations)                                                                       |                                        _String_ |  _undefined_ |
 | bookmark    |                                                                                 Attach bookmark to element. [See more](/advanced#bookmarks)                                                                                 | _String_ or [Bookmark](/advanced#bookmark-type) |  _undefined_ |
 
 ---
@@ -79,14 +80,15 @@ The most fundamental component for building a UI and is designed to be nested in
 
 #### Valid props
 
-| Prop name |                                  Description                                  |                                            Type |     Default |
-| --------- | :---------------------------------------------------------------------------: | ----------------------------------------------: | ----------: |
-| wrap      | Enable/disable page wrapping for element [See more](/advanced#page-wrapping)  |                                       _Boolean_ |      _true_ |
-| style     |                   Defines view styles. [See more](/styling)                   |                               _Object_, _Array_ | _undefined_ |
-| render    | Render dynamic content based on context [See more](/advanced#dynamic-content) |                                      _Function_ | _undefined_ |
-| debug     |   Enables debug mode on view bounding box. [See more](/advanced#debugging)    |                                       _Boolean_ |     _false_ |
-| fixed     |  Render component in all wrapped pages. [See more](/advanced#page-wrapping)   |                                       _Boolean_ |     _false_ |
-| bookmark  |          Attach bookmark to element. [See more](/advanced#bookmarks)          | _String_ or [Bookmark](/advanced#bookmark-type) | _undefined_ |
+| Prop name |                                   Description                                   |                                            Type |     Default |
+|-----------|:-------------------------------------------------------------------------------:|------------------------------------------------:|------------:|
+| wrap      |  Enable/disable page wrapping for element [See more](/advanced#page-wrapping)   |                                       _Boolean_ |      _true_ |
+| style     |                    Defines view styles. [See more](/styling)                    |                               _Object_, _Array_ | _undefined_ |
+| render    |  Render dynamic content based on context [See more](/advanced#dynamic-content)  |                                      _Function_ | _undefined_ |
+| debug     |    Enables debug mode on view bounding box. [See more](/advanced#debugging)     |                                       _Boolean_ |     _false_ |
+| fixed     |   Render component in all wrapped pages. [See more](/advanced#page-wrapping)    |                                       _Boolean_ |     _false_ |
+| id        | Destination to link to. Must begin with `#`. [See more](/advanced#destinations) |                                        _String_ | _undefined_ |
+| bookmark  |           Attach bookmark to element. [See more](/advanced#bookmarks)           | _String_ or [Bookmark](/advanced#bookmark-type) | _undefined_ |
 
 ---
 
@@ -127,13 +129,14 @@ A React component for displaying text. Text supports nesting of other Text or Li
 #### Valid props
 
 | Prop name           |                                       Description                                       |                                            Type |     Default |
-| ------------------- | :-------------------------------------------------------------------------------------: | ----------------------------------------------: | ----------: |
+|---------------------|:---------------------------------------------------------------------------------------:|------------------------------------------------:|------------:|
 | wrap                |     Enables/disables page wrapping for element [See more](/advanced#page-wrapping)      |                                       _Boolean_ |      _true_ |
 | render              |     Renders dynamic content based on context [See more](/advanced#dynamic-content)      |                                      _Function_ | _undefined_ |
 | style               |                        Defines view styles. [See more](/styling)                        |                               _Object_, _Array_ | _undefined_ |
 | debug               |        Enables debug mode on view bounding box. [See more](/advanced#debugging)         |                                       _Boolean_ |     _false_ |
 | fixed               |       Renders component in all wrapped pages. [See more](/advanced#page-wrapping)       |                                       _Boolean_ |     _false_ |
 | hyphenationCallback | Specify hyphenation callback at a text level. See [hypthenation](/advanced#hyphenation) |                                      _Function_ | _undefined_ |
+| id                  |     Destination to link to. Must begin with `#`. [See more](/advanced#destinations)     |                                        _String_ | _undefined_ |
 | bookmark            |               Attach bookmark to element. [See more](/advanced#bookmarks)               | _String_ or [Bookmark](/advanced#bookmark-type) | _undefined_ |
 
 ---
@@ -144,14 +147,14 @@ A React component for displaying an hyperlink. Link’s can be nested inside a T
 
 #### Valid props
 
-| Prop name |                                 Description                                  |                                            Type |     Default |
-| --------- | :--------------------------------------------------------------------------: | ----------------------------------------------: | ----------: |
-| src       |                                  Valid URL                                   |                                        _String_ | _undefined_ |
-| wrap      | Enable/disable page wrapping for element [See more](/advanced#page-wrapping) |                                       _Boolean_ |      _true_ |
-| style     |                  Defines view styles. [See more](/styling)                   |                               _Object_, _Array_ | _undefined_ |
-| debug     |   Enables debug mode on view bounding box. [See more](/advanced#debugging)   |                                       _Boolean_ |     _false_ |
-| fixed     |  Render component in all wrapped pages. [See more](/advanced#page-wrapping)  |                                       _Boolean_ |     _false_ |
-| bookmark  |         Attach bookmark to element. [See more](/advanced#bookmarks)          | _String_ or [Bookmark](/advanced#bookmark-type) | _undefined_ |
+| Prop name |                                  Description                                  |                                            Type |     Default |
+|-----------|:-----------------------------------------------------------------------------:|------------------------------------------------:|------------:|
+| src       |       Valid URL or destination name. [See more](/advanced#destinations)       |                                        _String_ | _undefined_ |
+| wrap      | Enable/disable page wrapping for element. [See more](/advanced#page-wrapping) |                                       _Boolean_ |      _true_ |
+| style     |                   Defines view styles. [See more](/styling)                   |                               _Object_, _Array_ | _undefined_ |
+| debug     |   Enables debug mode on view bounding box. [See more](/advanced#debugging)    |                                       _Boolean_ |     _false_ |
+| fixed     |  Render component in all wrapped pages. [See more](/advanced#page-wrapping)   |                                       _Boolean_ |     _false_ |
+| bookmark  |          Attach bookmark to element. [See more](/advanced#bookmarks)          | _String_ or [Bookmark](/advanced#bookmark-type) | _undefined_ |
 
 ---
 

--- a/docs/document-navigation.md
+++ b/docs/document-navigation.md
@@ -1,4 +1,34 @@
-### Bookmarks `v2.2.0`
+### Document Navigation
+
+There are two main ways to make a document navigable:
+
+#### Destinations `v2.0.0`
+
+Destinations are the simplest form of navigation. They allow to create interactive links that take the user directly to the defined place within the document.
+
+A destination can be created by setting the `id` prop to a _String_ with the leading hash (`#`) symbol on any supported element ([see more](/components)), and then linking to that id with the `<Link />` element:
+
+```js
+import { Document, Link, Page, Text } from '@react-pdf/renderer'
+
+const doc = () => (
+  <Document>
+    <Page>
+      <Link src='Footnote'> // No hash symbol
+        Click me to get to the footnote
+      </Link>
+
+      // Other content here
+
+      <Text id='#Footnote'> // Notice the leading hash symbol
+        You are here because you clicked the link above
+      </Text>
+    </Page>
+  </Document>
+);
+```
+
+#### Bookmarks `v2.2.0`
 
 Bookmarks allow the user to navigate interactively from one part of the document to another. They form a tree-structured hierarchy of items, which serve as a visual table of contents to display the document’s structure to the user.
 
@@ -17,6 +47,8 @@ const doc = () => (
 ```
 
 The example above will create a table of content of 2 nested items: The parent will be the book's name, and the child the chapter's name. You can nest as many bookmarks as you want.
+
+Note that some older PDF viewers may not support bookmarks.
 
 ##### Bookmark type
 

--- a/src/components/Layout/Menu.js
+++ b/src/components/Layout/Menu.js
@@ -185,7 +185,7 @@ const Menu = ({ opened }) => (
 
       <Item to="/advanced" title="Advanced">
         <Item to="/advanced#page-wrapping" title="Page wrapping" />
-        <Item to="/advanced#bookmarks" title="Bookmarks" />
+        <Item to="/advanced#document-navigation" title="Document Navigation" />
         <Item
           to="/advanced#on-the-fly-rendering"
           title="On the fly rendering"


### PR DESCRIPTION
This is a solution to an (non-)issue I've filed in the main `react-pdf` repo: diegomura/react-pdf#2110
1. Added proper [Named Destinations](https://pdfkit.org/docs/destinations.html) documentation with an example
2. Combined **Destinations** and **Bookmarks** sections in **Advanced** page into a single section called **Document Navigation**
3. Renamed and changed **Bookmarks** page link in `Menu` to **Document Navigation**
4. Added `id` prop to `Page`, `View`, and `Text` elements in **Components** page (as per [types](https://github.com/diegomura/react-pdf/tree/master/packages/types))
5. Added destination name to `Link`'s `src` prop definition in **Components** page