### PR TITLE
Add initial documentation about web workers

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -9,6 +9,7 @@ import DynamicContent from './dynamic-content.md'
 import Hyphenation from './hyphenation.md'
 import Debugging from './debugging.md'
 import Express from './express.md'
+import WebWorkers from './web-workers.md'
 
 <EditButton to="https://github.com/react-pdf/site/blob/master/docs/advanced.md" />
 
@@ -22,6 +23,7 @@ import Express from './express.md'
 <Debugging components={components} />
 <Hyphenation components={components} />
 <Express components={components} />
+<WebWorkers components={components} />
 
 <NavigationButtons
   backSrc="/styling"

--- a/docs/web-workers.md
+++ b/docs/web-workers.md
@@ -1,0 +1,8 @@
+### Rendering large documents in the browser
+
+If you need to render documents with 30 pages or more in the browser, using react-pdf directly in React can occupy the browser's main thread for a long time.
+This can lead to unresponsive UI and browsers offering the user to abort the script.
+To avoid this, you should render large documents inside a web worker.
+Web workers are executed in separate threads, and therefore do not block the main thread of the browser.
+This way, the UI can stay responsive while the PDF is being rendered.
+For an example on how to run react-pdf in a web worker, see this [blog post](https://dev.to/simonhessel/creating-pdf-files-without-slowing-down-your-app-a42).

--- a/src/components/Layout/Menu.js
+++ b/src/components/Layout/Menu.js
@@ -198,6 +198,7 @@ const Menu = ({ opened }) => (
         <Item to="/advanced#debugging" title="Debugging" />
         <Item to="/advanced#hyphenation" title="Hyphenation" />
         <Item to="/advanced#usage-with-express.js" title="Usage with Express.js" />
+        <Item to="/advanced#rendering-large-documents-in-the-browser" title="Rendering large documents" />
       </Item>
 
       <Item to="/repl" title="Playground / REPL" />


### PR DESCRIPTION
Link to a blog post from earlier this year explaining how to run react-pdf inside a web worker.

I'm thinking about how we could offer a web worker version directly from the react-pdf codebase. We can always replace the blog post link once we have that integration, but for now I wanted to have something in the docs.

Fixes diegomura/react-pdf#464
Fixes diegomura/react-pdf#736
Fixes diegomura/react-pdf#740
Fixes diegomura/react-pdf#1558
Fixes diegomura/react-pdf#1701
Fixes diegomura/react-pdf#2032

