### PR TITLE
Adding note about flexbox direction.

### DIFF
--- a/docs/styling.md
+++ b/docs/styling.md
@@ -148,6 +148,7 @@ const MyDocument = () => (
 ### Valid CSS properties
 
 #### Flexbox
+**By default react-pdf uses flexDirection col.** 
 
 - alignContent
 - alignItems


### PR DESCRIPTION
I had trouble using flexbox in react-pdf but realized it defaults to a column direction instead of row.