### PR TITLE
fix: make hyphenation callback id lowercase

### DIFF
--- a/docs/hyphenation.md
+++ b/docs/hyphenation.md
@@ -20,6 +20,6 @@ Font.registerHyphenationCallback(hyphenationCallback);
 
 You can use the [default hyphenation callback](https://github.com/diegomura/react-pdf/blob/master/packages/textkit/src/engines/wordHyphenation/index.js) as a starting point.
 
-> **Protip:** If you don't want to hyphenate words at all, just provide a callback that returns the same words it receives. More information [here](/fonts#registerHyphenationCallback)
+> **Protip:** If you don't want to hyphenate words at all, just provide a callback that returns the same words it receives. More information [here](/fonts#registerhyphenationcallback)
 
 <GoToExample name="hyphenation-callback" />


### PR DESCRIPTION
Fixes the id in the hyphenation callback link to correctly route.

Old link: https://react-pdf.org/fonts#registerHyphenationCallback
New link: https://site-git-fork-bdkopen-fix-hyphentation-callback-link-diegomura.vercel.app/fonts#registerhyphenationcallback
