### PR TITLE
feat: add Compatibility page

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,76 @@
+import EditButton from '../src/components/Docs/EditButton'
+import NavigationButtons from '../src/components/Docs/NavigationButtons'
+
+### Compatibility with Node.js
+
+We currently test react-pdf against Node.js 18, 20, and 21 (latest minors), so these are the versions we recommend using. Chances are you may use react-pdf with older versions of Node.js as well, but we can't guarantee it will work as expected.
+
+### Compatibility with Bun
+
+While we don't officially support Bun, we have received reports that it works well with react-pdf.
+
+### Compatibility with React
+
+react-pdf is compatible with React 16 (16.8.0 or later), React 17, and React 18.
+
+### Compatibility with Next.js
+
+In general, you may use react-pdf with Next.js regardless of the version. However, before Next.js 14.1.1, Next.js (App Router) suffered from a bug that caused the Next.js server to crash when using react-pdf. If you encounter:
+
+```
+TypeError: ba.Component is not a constructor
+```
+
+You should upgrade to Next.js 14.1.1 or later.
+
+If that's not possible, update your Next.js config like this:
+
+```js
+const nextConfig = {
+  // …
+  experimental: {
+    // …
+    serverComponentsExternalPackages: ['@react-pdf/renderer'],
+  }
+};
+```
+
+### Compatibility with esbuild
+
+If you are using esbuild to bundle your react-pdf application in ESM mode, you may encounter an error:
+
+```
+__dirname is not defined in ES module scope
+```
+
+This is because our dependency, [Yoga layout](https://yogalayout.com/), uses `__dirname` in their code.
+
+This will be fixed by the upcoming release of Yoga layout, but for now, you can work around this issue by using the `inject` option in esbuild.
+
+Create a file called `cjs-shim.ts`:
+
+```ts
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import url from 'node:url';
+
+globalThis.require = createRequire(import.meta.url);
+globalThis.__filename = url.fileURLToPath(import.meta.url);
+globalThis.__dirname = path.dirname(__filename);
+```
+
+Then, add it to your `esbuild.ts`:
+
+```ts
+await esbuild.build({
+  // …
+  inject: ['cjs-shim.ts'],
+});
+```
+
+And you should be good to go!
+
+<NavigationButtons
+  nextSrc="/rendering-process"
+  nextText="Rendering process"
+/>

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -101,6 +101,6 @@ ReactDOM.render(<App />, document.getElementById('root'));
 Maybe the most important step — make use of all react-pdf capabilities to create beautiful and awesome documents!
 
 <NavigationButtons
-  nextSrc="/rendering-process"
-  nextText="Rendering process"
+  nextSrc="/compatibility"
+  nextText="Compatibility"
 />

--- a/docs/rendering-process.md
+++ b/docs/rendering-process.md
@@ -47,8 +47,8 @@ The creation of the PDF document itself. For this task, we use the awesome [pdfk
 Once in this stage, we have our internal tree structure with all the needed data to generate our document. All it remains is deciding what we want to do with this data. This will vary depending on the binding you are using, but basically it means either displaying or saving it.
 
 <NavigationButtons
-  backSrc="/"
-  backText="Quick start guide"
+  backSrc="/compatibility"
+  backText="Compatibility"
   nextSrc="/components"
   nextText="Components"
 />

--- a/pages/compatibility.js
+++ b/pages/compatibility.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import Layout from '../src/components/Layout';
+import Compatibility from '../docs/compatibility.md'
+
+const RenderingProcessPage = () => {
+  return (
+    <Layout>
+      <Compatibility />
+    </Layout>
+  );
+};
+
+export default RenderingProcessPage;

--- a/src/components/Layout/Menu.js
+++ b/src/components/Layout/Menu.js
@@ -124,6 +124,8 @@ const Menu = ({ opened }) => (
     <List>
       <Item to="/" title="Quick start guide" />
 
+      <Item to="/compatibility" title="Compatibility" />
+
       <Item to="/rendering-process" title="Rendering process" />
 
       <Item to="/components" title="Components">
@@ -178,9 +180,9 @@ const Menu = ({ opened }) => (
       </Item>
 
       <Item to="/node" title="Node API">
-      <Item to="/node#rendertofile" title="renderToFile" />
-      <Item to="/node#rendertostring" title="renderToString" />
-      <Item to="/node#rendertostream" title="renderToStream" />
+        <Item to="/node#rendertofile" title="renderToFile" />
+        <Item to="/node#rendertostring" title="renderToString" />
+        <Item to="/node#rendertostream" title="renderToStream" />
       </Item>
 
       <Item to="/advanced" title="Advanced">


### PR DESCRIPTION
This commit adds Compatibility page, outlining supported Node.js versions, React versions, Next.js versions (and workarounds for older versions), and esbuild in ESM mode.

Closes https://github.com/diegomura/react-pdf/issues/2569