### PR TITLE
Fix: Correct Font File Path Repl Example

### DIFF
--- a/examples/font-register.txt
+++ b/examples/font-register.txt
@@ -2,19 +2,19 @@ Font.register({
   family: 'Roboto',
   fonts: [
     {
-      src: `/Roboto-Regular.ttf`
+      src: `fonts/Roboto-Regular.ttf`
     },
     {
-      src: `/Roboto-Bold.ttf`,
+      src: `fonts/Roboto-Bold.ttf`,
       fontWeight: 'bold'
     },
     {
-      src: `/Roboto-Italic.ttf`,
+      src: `fonts/Roboto-Italic.ttf`,
       fontWeight: 'normal',
       fontStyle: 'italic'
     },
     {
-      src: `/Roboto-BoldItalic.ttf`,
+      src: `fonts/Roboto-BoldItalic.ttf`,
       fontWeight: 'bold',
       fontStyle: 'italic'
     }


### PR DESCRIPTION
- Fixes the file paths for the font example

Deployment preview: https://site-7bsx-git-fork-bdkopen-fi-7f61a9-diego-muraccioles-projects.vercel.app/repl?example=font-register

Resolves issue: https://github.com/diegomura/react-pdf/issues/2879