### PR TITLE
Added a comprehensive example of a custom hyphenation using the German language as an example

### DIFF
--- a/docs/hyphenation.md
+++ b/docs/hyphenation.md
@@ -20,6 +20,16 @@ Font.registerHyphenationCallback(hyphenationCallback);
 
 You can use the [default hyphenation callback](https://github.com/diegomura/react-pdf/blob/master/packages/textkit/src/engines/wordHyphenation/index.js) as a starting point.
 
+Example of a custom implementation (German):
+```
+import { Font } from "@react-pdf/renderer";
+import { hyphenateSync as hyphenateDE } from "hyphen/de";
+
+const hyphenationCallback = (word) => {
+  return hyphenateDE(word).split("\u00AD");
+};
+```
+
 > **Protip:** If you don't want to hyphenate words at all, just provide a callback that returns the same words it receives. More information [here](/fonts#registerhyphenationcallback)
 
 <GoToExample name="hyphenation-callback" />

--- a/docs/hyphenation.md
+++ b/docs/hyphenation.md
@@ -28,6 +28,8 @@ import { hyphenateSync as hyphenateDE } from "hyphen/de";
 const hyphenationCallback = (word) => {
   return hyphenateDE(word).split("\u00AD");
 };
+
+Font.registerHyphenationCallback(hyphenationCallback);
 ```
 
 > **Protip:** If you don't want to hyphenate words at all, just provide a callback that returns the same words it receives. More information [here](/fonts#registerhyphenationcallback)


### PR DESCRIPTION
It took me a while to figure out how a proper custom implementation of hyphenation should look like. I think it would be useful to add a comprehensive example to the docs.

Added example of custom hyphenation.