### PR TITLE
Improve instructions on correct twemoji use

### DIFF
--- a/docs/fonts.md
+++ b/docs/fonts.md
@@ -138,18 +138,34 @@ Font.registerHyphenationCallback(word => [word]);
 
 PDF documents do not support color emoji fonts. This is a bummer for the ones out there who love their expressiveness and simplicity. The only way of rendering this glyphs on a PDF document, is by embedding them as images.
 
-React-pdf makes this task simple by enabling you to use a CDN from where to download emoji images. All you have to do is setup a valid URL (we recommend using [Twemoji](https://github.com/twitter/twemoji) for this task), and react-pdf will take care of the rest:
+React-pdf makes this task simple by enabling you to use a CDN from where to download emoji images. All you have to do is setup a valid URL, and react-pdf will take care of the rest:
 
 ```
 import { Font } from '@react-pdf/renderer'
 
 Font.registerEmojiSource({
   format: 'png',
-  url: 'https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/72x72/',
+  url: 'https://source-of-your-emoji-images.com/png/',
 });
 ```
 
-> **Protip:** react-pdf will need a internet connection to download emoji's images at render time, so bare that in mind when choosing to use this API
+A simple public package providing the emoji images is [Twemoji](https://github.com/twitter/twemoji). To use twemoji, you need to specify a builder function for the emoji image URLs instead, because of some conventions regarding filenames which twemoji uses:
+
+```
+import { Font } from '@react-pdf/renderer'
+
+Font.registerEmojiSource({
+  withVariationSelectors: true,
+  builder(code) {
+    const filename = code.includes('200d')
+      ? code
+      : code.split('-').filter((part) => part && part !== 'fe0f').join('-')
+    return 'https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/72x72/' + filename + '.png'
+  },
+});
+```
+
+> **Protip:** react-pdf will need a internet connection to download emoji's images at render time, so bear that in mind when choosing to use this API, or host the images yourself.
 
 <GoToExample name="emoji" />
 

--- a/examples/emoji.txt
+++ b/examples/emoji.txt
@@ -11,8 +11,13 @@ const styles = StyleSheet.create({
 });
 
 Font.registerEmojiSource({
-  format: 'png',
-  url: 'https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/72x72/',
+  withVariationSelectors: true,
+  builder(code) {
+    const filename = code.includes('200d')
+      ? code
+      : code.replaceAll('fe0f', '').replaceAll(/--|^-|-$/g, '')
+    return 'https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/72x72/' + filename + '.png'
+  },
 });
 
 const MyDocument = () => (
@@ -20,7 +25,7 @@ const MyDocument = () => (
     <Page>
       <View style={styles.container}>
         <Text style={styles.text}>
-          😀💩👻🙈
+          😀💩👻🙈🕊️🧙‍♂️
         </Text>
       </View>
     </Page>


### PR DESCRIPTION
The twemoji library strips one code point from the emoji file names in some cases, see https://github.com/twitter/twemoji/issues/419#issuecomment-637360325

As a specific example, the male mage emoji 🧙‍♂️ consists of [4 code points](https://apps.timwhitlock.info/unicode/inspect?s=%F0%9F%A7%99%E2%80%8D%E2%99%82%EF%B8%8F):
- 1f9d9 mage
- 200d  zero width joiner
- 2642  male sign
- fe0f  variation selector 16 And the correct twemoji filename is: `/twemoji/assets/72x72/1f9d9-200d-2642-fe0f.png`

On the other hand, the dove emoji 🕊️ consists of [2 code points](https://apps.timwhitlock.info/unicode/inspect?s=%F0%9F%95%8A%EF%B8%8F):
- 1f54a dove
- fe0f  variation selector 16 And the correct twemoji filename is: `/twemoji/assets/72x72/1f54a.png` (note the omitted variation selector)

In the twemoji library, according to the linked comment, the variation selector is removed in simple emoji without a zero width joiner, but preserved in combined emoji with a zero width joiner. Therefore, to use twemoji, we should recomment applications to mirror this transformation. **The [current emoji example](https://react-pdf.org/repl?example=emoji) crashes when a male mage emoji 🧙‍♂️ is inserted into the text, even though twemoji contains this emoji.**

Different emoji libraries can handle this differently, which is why it can't really be fixed on the react-pdf side.