### PR TITLE
docs: document float, clear and shapeOutside

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -5,6 +5,7 @@ import PageWrapping from './page-wrapping.md'
 import DocumentNavigation from './document-navigation.md'
 import OnTheFly from './on-the-fly.md'
 import OrphanWidowProtection from './orphan-widow-protection.md'
+import Floats from './floats.md'
 import DynamicContent from './dynamic-content.md'
 import Hyphenation from './hyphenation.md'
 import Debugging from './debugging.md'
@@ -20,6 +21,7 @@ import Math from './math.md'
 <DocumentNavigation components={components} />
 <OnTheFly components={components} />
 <OrphanWidowProtection components={components} />
+<Floats components={components} />
 <DynamicContent components={components} />
 <Debugging components={components} />
 <Hyphenation components={components} />

--- a/docs/floats.md
+++ b/docs/floats.md
@@ -1,0 +1,66 @@
+import GoToExample from '../src/components/Docs/GoToExample'
+
+### Floats
+
+react-pdf supports CSS floats. A floated element is taken out of the normal flow and pinned to one side of its container, with the surrounding text wrapping around it. This is the tool for drop caps, figures with captions, pull quotes and other article-style layouts.
+
+Set `float` to `left` or `right` on any View or Image, and place the wrapping text as its sibling:
+
+```
+import React from 'react';
+import { Page, Text, View, Image, Document } from '@react-pdf/renderer';
+
+const MyDocument = () => (
+  <Document>
+    <Page size="A4" style={{ padding: 40, fontSize: 12 }}>
+      <View style={{ float: 'right', width: 150, marginLeft: 10 }}>
+        <Image src="/my-image.jpg" style={{ width: 150 }} />
+      </View>
+      <Text>
+        This text wraps along the left side of the image, and recovers the
+        full width of the page once past its bottom edge...
+      </Text>
+    </Page>
+  </Document>
+);
+```
+
+A float only affects the lines that overlap it vertically, and margins on the floated element define the gap between it and the text. Anything nested inside the floated element (a caption, for instance) travels with it and takes no part in the wrapping.
+
+> **Protip:** Text wrapping is resolved at layout time, so react-pdf may measure a wrapping paragraph shorter than it ends up being. If content below overlaps it, reserve the real height on the wrapping container with `minHeight`
+
+#### Clear
+
+The `clear` property moves an element below preceding floats, just like in CSS. Valid values are `left`, `right`, `both` and `none` _(default)_:
+
+```
+<View style={{ float: 'left', width: 80, height: 80 }} />
+<Text>This text wraps around the float</Text>
+<Text style={{ clear: 'left' }}>This text starts below it</Text>
+```
+
+#### Shape outside
+
+By default text wraps around the float's rectangular box. The `shapeOutside` property replaces that rectangle with a CSS basic shape — `circle()`, `ellipse()`, `polygon()` or `inset()` — and text wraps along it instead:
+
+```
+<View
+  style={{
+    float: 'left',
+    width: 100,
+    height: 100,
+    shapeOutside: 'circle(50%)',
+  }}
+>
+  <Svg width={100} height={100}>
+    <Circle cx={50} cy={50} r={50} fill="tomato" />
+  </Svg>
+</View>
+<Text>This text creeps in toward the circle, line by line...</Text>
+```
+
+Shape coordinates and radii accept the same units and percentages as CSS, resolved against the float's box.
+
+<GoToExample name="float" />
+
+---

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -168,10 +168,13 @@ const MyDocument = () => (
 
 - aspectRatio
 - bottom
+- clear _(left, right, both, none)_
 - display
+- float _(left, right)_
 - left
 - position _(relative, absolute, static)_
 - right
+- shapeOutside _(circle, ellipse, polygon, inset)_
 - top
 - overflow
 - zIndex

--- a/examples/float.txt
+++ b/examples/float.txt
@@ -1,0 +1,90 @@
+const styles = StyleSheet.create({
+  page: {
+    padding: 40,
+    fontSize: 11,
+    fontFamily: 'Times-Roman',
+  },
+  section: {
+    marginBottom: 30,
+  },
+  text: {
+    textAlign: 'justify',
+  },
+});
+
+const doc = (
+  <Document>
+    <Page style={styles.page} size="A4">
+      <View style={styles.section}>
+        <View style={{ float: 'left', marginRight: 6 }}>
+          <Text style={{ fontSize: 46, fontFamily: 'Times-Bold', color: '#4069b4' }}>
+            E
+          </Text>
+        </View>
+        <Text style={styles.text}>
+          n un lugar de la Mancha, de cuyo nombre no quiero acordarme, no ha
+          mucho tiempo que vivía un hidalgo de los de lanza en astillero,
+          adarga antigua, rocín flaco y galgo corredor. Una olla de algo más
+          vaca que carnero, salpicón las más noches, duelos y quebrantos los
+          sábados, lentejas los viernes, algún palomino de añadidura los
+          domingos, consumían las tres partes de su hacienda. El resto della
+          concluían sayo de velarte, calzas de velludo para las fiestas con
+          sus pantuflos de lo mismo, los días de entre semana se honraba con
+          su vellori de lo más fino.
+        </Text>
+      </View>
+
+      <View style={styles.section}>
+        <View
+          style={{
+            float: 'right',
+            width: 120,
+            height: 90,
+            marginLeft: 10,
+            backgroundColor: '#c25b56',
+          }}
+        />
+        <Text style={styles.text}>
+          Tenía en su casa una ama que pasaba de los cuarenta, y una sobrina
+          que no llegaba a los veinte, y un mozo de campo y plaza, que así
+          ensillaba el rocín como tomaba la podadera. Frisaba la edad de
+          nuestro hidalgo con los cincuenta años, era de complexión recia,
+          seco de carnes, enjuto de rostro; gran madrugador y amigo de la
+          caza. Quieren decir que tenía el sobrenombre de Quijada o Quesada,
+          aunque por conjeturas verosímiles se deja entender que se llama
+          Quijana; pero esto importa poco a nuestro cuento.
+        </Text>
+        <Text style={{ clear: 'right', marginTop: 8 }}>
+          This line has clear: right, so it starts below the float.
+        </Text>
+      </View>
+
+      <View style={styles.section}>
+        <View
+          style={{
+            float: 'left',
+            width: 100,
+            height: 100,
+            shapeOutside: 'circle(50%)',
+          }}
+        >
+          <Svg width={100} height={100}>
+            <Circle cx={50} cy={50} r={46} fill="#55987a" />
+          </Svg>
+        </View>
+        <Text style={styles.text}>
+          With shapeOutside the text wraps along a circle instead of the
+          float's rectangular box: lines are short where the circle is
+          widest and longer near its top and bottom, where the curve falls
+          away. Es, pues, de saber que este sobredicho hidalgo, los ratos
+          que estaba ocioso, que eran los más del año, se daba a leer libros
+          de caballerías, con tanta afición y gusto, que olvidó casi de todo
+          punto el ejercicio de la caza y aun la administración de su
+          hacienda.
+        </Text>
+      </View>
+    </Page>
+  </Document>
+);
+
+ReactPDF.render(doc);

--- a/pages/repl.js
+++ b/pages/repl.js
@@ -45,6 +45,7 @@ const examples = {
   'page-numbers': require('raw-loader!../examples/page-numbers.txt'),
   'mixed-styles': require('raw-loader!../examples/mixed-styles.txt'),
   'inline-styles': require('raw-loader!../examples/inline-styles.txt'),
+  float: require('raw-loader!../examples/float.txt'),
   math: require('raw-loader!../examples/math.txt'),
   lineargradient: require('raw-loader!../examples/lineargradient.txt'),
   radialgradient: require('raw-loader!../examples/radialgradient.txt'),

--- a/src/components/Layout/Menu.js
+++ b/src/components/Layout/Menu.js
@@ -206,6 +206,7 @@ const Menu = ({ opened }) => (
           to="/advanced#orphan-&-widow-protection"
           title="Orphan and widow protection"
         />
+        <Item to="/advanced#floats" title="Floats" />
         <Item to="/advanced#dynamic-content" title="Dynamic content" />
         <Item to="/advanced#debugging" title="Debugging" />
         <Item to="/advanced#hyphenation" title="Hyphenation" />


### PR DESCRIPTION
Documents the new float feature landing in the next react-pdf release (diegomura/react-pdf#3286, #3514).

- New "Floats" section under Advanced covering `float: left | right`, `clear`, and `shapeOutside` with the `circle()` / `ellipse()` / `polygon()` / `inset()` basic shapes, plus a note on reserving wrap height with `minHeight`.
- Adds `float`, `clear` and `shapeOutside` to the valid CSS properties list in Styling, and a "Floats" entry to the sidebar menu.
- Adds a `float` REPL example (drop cap, right float with clear, circle shape-outside) linked from the docs.

Note: the REPL bundles `@react-pdf/renderer` ^4.7.0, so the example won't render floats until the release ships and the dep is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)