### PR TITLE
docs: document @react-pdf/hyphenate language entry points

### DIFF
--- a/docs/fonts.md
+++ b/docs/fonts.md
@@ -149,6 +149,15 @@ const hyphenationCallback = (word) => {
 Font.registerHyphenationCallback(hyphenationCallback);
 ```
 
+To hyphenate a language other than the default `en-us`, register a `syllables` function from [@react-pdf/hyphenate](https://github.com/diegomura/react-pdf/tree/master/packages/hyphenate):
+
+```
+import { Font } from '@react-pdf/renderer';
+import { syllables } from '@react-pdf/hyphenate/de';
+
+Font.registerHyphenationCallback(syllables);
+```
+
 <GoToExample name="hyphenation-callback" />
 
 #### Disabling hyphenation

--- a/docs/hyphenation.md
+++ b/docs/hyphenation.md
@@ -6,6 +6,21 @@ Hyphenation refers to the automated process of breaking words between lines to c
 
 React-pdf internally implements the [Knuth and Plass line breaking algorithm](http://www.eprg.org/G53DOC/pdfs/knuth-plass-breaking.pdf) that produces the minimum amount of lines without compromising text legibility. By default it's setup to hyphenate english words.
 
+#### Other languages
+
+Words are split with [@react-pdf/hyphenate](https://github.com/diegomura/react-pdf/tree/master/packages/hyphenate), a fast Liang hyphenation engine with an entry point per language, `en-us` being the default. To hyphenate another language, register its `syllables` function:
+
+```
+import { Font } from '@react-pdf/renderer';
+import { syllables } from '@react-pdf/hyphenate/de';
+
+Font.registerHyphenationCallback(syllables);
+```
+
+Every language shipped by [hyphen](https://github.com/ytiurin/hyphen) is available under the same name (`de`, `es`, `fr`, `ru`, `zh-latn-pinyin`, and 80+ more). Each language is its own entry point, so bundlers only include the patterns you actually import.
+
+#### Custom callback
+
 If you need more fine-grained control over how words break, you can pass your own callback and handle all that logic by yourself:
 
 ```
@@ -14,20 +29,6 @@ import { Font } from '@react-pdf/renderer'
 const hyphenationCallback = (word) => {
   // Return word syllables in an array
 }
-
-Font.registerHyphenationCallback(hyphenationCallback);
-```
-
-You can use the [default hyphenation callback](https://github.com/diegomura/react-pdf/blob/master/packages/textkit/src/engines/wordHyphenation/index.ts) as a starting point.
-
-Example of a custom implementation (German):
-```
-import { Font } from "@react-pdf/renderer";
-import { hyphenateSync as hyphenateDE } from "hyphen/de";
-
-const hyphenationCallback = (word) => {
-  return hyphenateDE(word).split("\u00AD");
-};
 
 Font.registerHyphenationCallback(hyphenationCallback);
 ```


### PR DESCRIPTION
Documents the new trie-based `@react-pdf/hyphenate` package (react-pdf#3494, now textkit's default engine) on the hyphenation and fonts pages.

- `docs/hyphenation.md`: adds an "Other languages" section showing per-language entry points registered via `Font.registerHyphenationCallback(syllables)`, replacing the old third-party `hyphen` German example and a stale link to textkit internals.
- `docs/fonts.md`: adds the same language-registration snippet under `registerHyphenationCallback`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)