### PR TITLE
docs: point readme to new site home

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# react-pdf-site
+
+> [!NOTE]
+> This repository is archived. The react-pdf site now lives in the main
+> [react-pdf](https://github.com/diegomura/react-pdf) monorepo under
+> [`apps/site`](https://github.com/diegomura/react-pdf/tree/master/apps/site).
+> Please open issues and pull requests there.
+
+Source for [react-pdf.org](https://react-pdf.org).


### PR DESCRIPTION
The site now lives in the react-pdf monorepo under \`apps/site\`. Adds a README note pointing there ahead of archiving this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)